### PR TITLE
Start making vtest command arguments less positional

### DIFF
--- a/tests/a00024.vtc
+++ b/tests/a00024.vtc
@@ -17,6 +17,7 @@ server s2  {
 	txresp
 	rxreq
 	# default User-Agent header is not included when -nouseragent is specified
+	expect req.http.foo == bar
 	expect req.http.User-Agent == <undef>
 	txresp -noserver
 } -start
@@ -36,7 +37,7 @@ client c202 -connect ${s2_sock} {
 	txreq
 	rxresp
 	expect resp.http.Server == "s2"
-	txreq -nouseragent
+	txreq -hdr "foo: bar" -nouseragent
 	rxresp
 	# default Server header is not included when -noserver is specified
 	expect resp.http.Server == <undef>


### PR DESCRIPTION
**NB:** This patch does _not_ work with vtest as-is because of other missing patches. Before running into more of a chicken/egg double maintenance situation, I would prefer to achieve consensus about https://github.com/nigoroll/vtest2/ (see also https://github.com/varnishcache/varnish-cache/pull/4333). This patch currently is in vtest2 WIP as https://github.com/nigoroll/vtest2/commit/a907e429b121d5cb893b90474c170facce389147, but I am not sold on it.

This ticket is to ask about feedback.

Our common pattern of argument parsing is basically

```c
	for (; *av != NULL; av++) {
		// parse first set of arguments
		if (unknown_argument)
			break;
	}
	for (; *av != NULL; av++) {
		// parse second set of arguments
		if (unknown_argument)
			break;
	}
	// ...
```

This makes vtest command arguments "semi-positional": Within each set, they behave like named arguments usually do, but once parsing progressed to the next set, they behave like positional arguments. This is explicitly mentioned in the documentation, for example for txreq/txresp:

> 	"These three switches can appear in any order but must come
> 	 before the following ones."

While properly documented, this is un-POLA behavior.

This patch changes this behavior for the first set of txreq/txresp arguments in a simplistic way by filtering known arguments out of the argument vector. The drawback of the simplistic approach is that argument values of a "later stage" can not be the same string as argument names of an "earlier stage". For example, the following would no longer work:

```
	txreq -body -nouseragent
```

Do we want this compromise? If not, I would prefer to just stick to "RTFM".

In Response to vtest/VTest2#1 